### PR TITLE
Facilidades para levantar ambiente local de desarrollo

### DIFF
--- a/hgathering.sh
+++ b/hgathering.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+MONGO_CONT=${MONGO_CONT:-"mongo-3.4"}
+MONGO_TAG=${MONGO_TAG:-"3.4"}
+
+case "$1" in
+    mongo-fresh)
+        docker run --name $MONGO_CONT -d -p 27017:27017 mongo:$MONGO_TAG
+        ;;
+    mongo-start)
+        docker start $MONGO_CONT
+        ;;
+    mongo-rmf)
+        docker rm -f $MONGO_CONT
+        ;;
+    start)
+        npm start
+        ;;
+    *)
+        echo "Usage: $0 {mongo-fresh|mongo-start|mongo-rmf|start}"
+        ;;
+esac

--- a/hgathering.sh
+++ b/hgathering.sh
@@ -13,10 +13,13 @@ case "$1" in
     mongo-rmf)
         docker rm -f $MONGO_CONT
         ;;
+    mongo-restore)
+        mongorestore --host=localhost --db=help_mx $2
+        ;;
     start)
         npm start
         ;;
     *)
-        echo "Usage: $0 {mongo-fresh|mongo-start|mongo-rmf|start}"
+        echo "Usage: $0 {mongo-fresh|mongo-start|mongo-rmf|mongo-restore|start}"
         ;;
 esac

--- a/server/datasources.development.json
+++ b/server/datasources.development.json
@@ -1,0 +1,10 @@
+{
+  "mlab": {
+    "host": "localhost",
+    "port": 27017,
+    "url": "mongodb://localhost:27017/help_mx",
+    "database": "help_mx",
+    "name": "mlab",
+    "connector": "mongodb"
+  }
+}


### PR DESCRIPTION
# `hgathering.sh`

Permite realizar tareas comunes para levantar el servicio con unos cuantos comandos. La forma de utilizarlo es

```
./hgathering.sh <comando> [<arg1>]
```

Donde `<comando>` es una de las siguientes opciones:

- `mongo-fresh`: Crea un nuevo contenedor basado en la imagen de mongo:3.4
- `mongo-start`: Inicia el contenedor de mongo existente.
- `mongo-rmf`: Elimina el contenedor de mongo existente.
- `mongo-restore`: Restaura el dump de una bd en la instancia local de mongo. Aquí se utiliza `<arg1>` como el directorio en donde se encuentran los archivos del dump.
- `start`: Inicia el servicio con `npm start`

# `server/datasources.development.js`

Reemplaza valores específicos de la configuración base del archivo `server/datasources.json`. Lo que vale la pena mencionar es que quité las llaves de `user` y `password` porque la instancia local de mongo no tiene por qué usar autenticación en un ambiente dev.

Nota: Varios archivos de configuración del directorio `server/` se pueden "refinar" con un archivo más específico añadiendo una palabra con el ambiente en que se ejecuta el servicio, en este caso se usó `development` porque es el ambiente default para ejecutar un servicio. Para modificar el ambiente se puede reasignar la variable NODE_ENV con algún otro valor al ejecutar `./hgathering.sh start` o directamente `npm start`.